### PR TITLE
doctrine proxy reflection fix

### DIFF
--- a/src/Traits/Transformable.php
+++ b/src/Traits/Transformable.php
@@ -28,6 +28,10 @@ trait Transformable {
         if(!$ar) { $ar = static::createCachedReader(); }
         if(!$pr) { $pr = new PolicyResolver(); }
         $refClass = new \ReflectionClass($this);
+        if ($refClass->getName() !== static::getEntityFullName($refClass)) {
+            // if this was a proxy, use the base class for reflection
+            $refClass = new \ReflectionClass(static::getEntityFullName($refClass));
+        }
         $result = ['__meta' => ['class' => static::getEntityFullName($refClass)]];
         $ps = $refClass->getProperties(  \ReflectionProperty::IS_PUBLIC
                                        | \ReflectionProperty::IS_PROTECTED


### PR DESCRIPTION
when Doctrine proxy objects are returned, some properties are not serialized.  this is fixed by using the root data type for reflection property lookup.